### PR TITLE
Update sites.js.coffee.erb

### DIFF
--- a/app/assets/javascripts/sites.js.coffee.erb
+++ b/app/assets/javascripts/sites.js.coffee.erb
@@ -244,7 +244,7 @@ $(document).ready ->
                 else
                   $(this).addClass 'selected_img'
                   queue.push(file)
-                  if queue.length < simultaneous_upload
+                  if queue.length > simultaneous_upload
                     file_list.push(file)
                   $("#upload-msg").append('<p class="status-info">Image ' + file.name + " added to upload queue</p>")
                 


### PR DESCRIPTION
fix for queuing, now generates thumbnails for queued images instead of blocking upload of more than 10 images
